### PR TITLE
feat(plugin) : Cross plugin search registry

### DIFF
--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -1134,6 +1134,10 @@ pub struct ExternalTrackInput {
     pub format: Option<String>,
     pub bitrate: Option<i32>,
     pub stream_url: Option<String>, // The decoded stream URL
+    pub track_number: Option<i32>,
+    pub disc_number: Option<i32>,
+    pub musicbrainz_recording_id: Option<String>,
+    pub metadata_json: Option<String>,
 }
 
 /// Add an external (streaming) track to the library
@@ -1172,8 +1176,8 @@ pub async fn add_external_track(
         title: Some(track.title),
         artist: Some(track.artist),
         album: track.album,
-        track_number: None,
-        disc_number: None,
+        track_number: track.track_number,
+        disc_number: track.disc_number,
         duration: track.duration,
         album_art: None,   // External tracks use cover_url instead
         track_cover: None, // External tracks use cover_url instead
@@ -1184,8 +1188,8 @@ pub async fn add_external_track(
         external_id: Some(track.external_id),
         content_hash,
         local_src: None,
-        musicbrainz_recording_id: None,
-        metadata_json: None,
+        musicbrainz_recording_id: track.musicbrainz_recording_id,
+        metadata_json: track.metadata_json,
     };
 
     queries::insert_or_update_track(&conn, &track_insert)

--- a/src/lib/api/tauri.ts
+++ b/src/lib/api/tauri.ts
@@ -278,6 +278,11 @@ export interface ExternalTrackInput {
     external_id: string;  // Source-specific ID
     format?: string;
     bitrate?: number;
+    stream_url?: string;
+    track_number?: number;
+    disc_number?: number;
+    musicbrainz_recording_id?: string;
+    metadata_json?: string;
 }
 
 export async function addExternalTrack(track: ExternalTrackInput): Promise<number> {

--- a/src/lib/plugins/runtime.ts
+++ b/src/lib/plugins/runtime.ts
@@ -111,6 +111,55 @@ class PluginPermissionManager {
   }
 }
 
+// search registry types 
+
+export interface SearchQuery {
+  title: string;
+  artist?: string;
+  isrc?: string;
+  duration_ms?: number;
+}
+
+export interface SearchResult {
+  sourceId: string;
+  status: 'success' | 'error' | 'not_found';
+
+  // on success
+  title?: string;
+  artist?: string;
+  album?: string;
+  duration?: number;
+  external_id?: string;
+  source_type?: string;
+  format?: string | null;
+  bitrate?: number | null;
+  track_number?: number | null;
+  disc_number?: number | null;
+  cover_url?: string | null;
+  album_art?: string | null;
+  track_cover?: string | null;
+  // Identifiers
+  musicbrainz_recording_id?: string | null;
+
+  // Catch-all for source-specific extras that don't map to a schema column
+  // (ISRC, composer, replay gain, quality tier, source-internal flags).
+  // Stored as-is in the metadata_json column . callers can read it back via raw.
+  metadata_json?: Record<string, any> | null;
+  score?: number;
+  raw?: any;
+
+  // on error
+  error?: Error;
+}
+
+// search source handler receives query and an onResult callback
+// it must call onResult exactly once with status like success, not_found,error
+// runtime uses this guarantee to know when all sources have reported back
+export type SearchSourceHandler = (
+  query: SearchQuery,
+  onResult: (result: SearchResult) => void
+) => void;
+
 export interface WasmPluginExports {
   init?: () => void;
   start?: () => void;
@@ -150,6 +199,11 @@ export class PluginRuntime {
   // Stream resolvers: map of source_type -> resolver function
   // Resolver takes (external_id, options?) and returns Promise<string | null> (stream URL)
   streamResolvers: Map<string, (externalId: string, options?: any) => Promise<string | null>> = new Map();
+
+  // search sources: map of sourceId => handler function
+  private searchSources: Map<string, SearchSourceHandler> = new Map();
+  // track which plugin owns which source (for cleanup on unload)
+  private searchSourceOwners: Map<string, string> = new Map(); // sourceId => pluginName
 
   // permission manager
   permissionManager: PluginPermissionManager;
@@ -645,11 +699,19 @@ export class PluginRuntime {
             album: trackData.album || null,
             duration: trackData.duration || null,
             cover_url: trackData.cover_url || null,
+            album_art: trackData.album_art || null,
+            track_cover: trackData.track_cover || null,
             source_type: trackData.source_type,
             external_id: trackData.external_id,
             format: trackData.format || null,
             bitrate: trackData.bitrate || null,
-            stream_url: trackData.stream_url || null  // The decoded stream URL
+            stream_url: trackData.stream_url || null,  // The decoded stream URL
+            track_number: trackData.track_number || null,
+            disc_number: trackData.disc_number || null,
+            musicbrainz_recording_id: trackData.musicbrainz_recording_id || null,
+            metadata_json: trackData.metadata_json
+              ? JSON.stringify(trackData.metadata_json)
+              : null,
           }
         });
 
@@ -766,7 +828,25 @@ export class PluginRuntime {
     if (this.hasPermission(pluginName, 'library:write')) {
       if (!api.library) api.library = {};
       api.library.downloadTrack = (options: any) => this.callHost(pluginName, 'library.downloadTrack', options);
-      api.library.addExternalTrack = (trackData: any) => this.callHost(pluginName, 'library.addExternalTrack', trackData);
+      api.library.addExternalTrack = (trackData: {
+        title: string;
+        artist: string;
+        album?: string | null;
+        duration?: number | null;
+        cover_url?: string | null;
+        album_art?: string | null;
+        track_cover?: string | null;
+        source_type: string;
+        external_id: string;
+        format?: string | null;
+        bitrate?: number | null;
+        stream_url?: string | null;
+        track_number?: number | null;
+        disc_number?: number | null;
+        musicbrainz_recording_id?: string | null;
+        metadata_json?: Record<string, any> | null;
+      }) => this.callHost(pluginName, 'library.addExternalTrack', trackData);
+
       api.library.refresh = () => this.callHost(pluginName, 'library.refresh');
       api.library.createPlaylist = (name: string) => this.callHost(pluginName, 'library.createPlaylist', name);
       api.library.addTrackToPlaylist = (playlistId: number, trackId: number) => this.callHost(pluginName, 'library.addTrackToPlaylist', playlistId, trackId);
@@ -815,6 +895,74 @@ export class PluginRuntime {
         }
       };
     }
+
+    // search registry
+    // sources register themselves; consumers query all sources at once and receive
+    // one search result per source via onResult, then a single onAllDone when
+    // every source has reported back (regardless of success / error / not_found).
+    api.search = {
+      // register this plugin as a searchable source.
+      // handler(query, onResult) .must call onResult exactly once.
+      registerSource: (sourceId: string, handler: SearchSourceHandler) => {
+        if (this.searchSources.has(sourceId)) {
+          console.warn(`[PluginRuntime] Search source '${sourceId}' is already registered ; overwriting (previous owner: '${this.searchSourceOwners.get(sourceId)}')`);
+        }
+        this.searchSources.set(sourceId, handler);
+        this.searchSourceOwners.set(sourceId, pluginName);
+        console.log(`[PluginRuntime] Registered search source '${sourceId}' from plugin '${pluginName}'`);
+      },
+
+      // unregister this plugin's search source.
+      // only the owning plugin can remove its own source.
+      unregisterSource: (sourceId: string) => {
+        if (this.searchSourceOwners.get(sourceId) !== pluginName) {
+          console.warn(`[PluginRuntime] Plugin '${pluginName}' tried to unregister search source '${sourceId}' it does not own`);
+          return;
+        }
+        this.searchSources.delete(sourceId);
+        this.searchSourceOwners.delete(sourceId);
+        console.log(`[PluginRuntime] Unregistered search source '${sourceId}' from plugin '${pluginName}'`);
+      },
+
+      // fan a query out to every registered source in parallel
+      // onResult is called once per source status:success, not_found,error
+      // onAllDone is called once after every source has reported back
+      // if no sources are registered, onAllDone is called immediately with an empty result set
+      query: (
+        query: SearchQuery,
+        onResult: (result: SearchResult) => void,
+        onAllDone: () => void
+      ) => {
+        if (this.searchSources.size === 0) {
+          console.warn(`[PluginRuntime] search.query called by '${pluginName}' but no search sources are registered`);
+          onAllDone();
+          return;
+        }
+
+        // track which sources are still pending
+        // runtime wraps onResult per-source
+        const pending = new Set(this.searchSources.keys());
+
+        for (const [sourceId, handler] of this.searchSources) {
+          const wrappedOnResult = (result: SearchResult) => {
+            // ensure sourceId is stamped
+            result.sourceId = sourceId;
+            onResult(result);
+            pending.delete(sourceId);
+            if (pending.size === 0) onAllDone();
+          };
+
+          try {
+            handler(query, wrappedOnResult);
+          } catch (err) {
+            // if a handler throws, treat it as error
+            // so onAllDone still fires
+            console.error(`[PluginRuntime] Search source '${sourceId}' threw synchronously:`, err);
+            wrappedOnResult({ sourceId, status: 'error', error: err as Error });
+          }
+        }
+      }
+    };
 
     // Network API - CORS-free fetch (always available for plugins with network:fetch permission)
     if (this.hasPermission(pluginName, 'network:fetch')) {
@@ -1059,6 +1207,15 @@ export class PluginRuntime {
         }
       });
 
+      // unregister search sources owned by this plugin
+      this.searchSourceOwners.forEach((owner, sourceId) => {
+        if (owner === name) {
+          this.searchSources.delete(sourceId);
+          this.searchSourceOwners.delete(sourceId);
+          console.log(`[PluginRuntime] Unregistered search source '${sourceId}' (plugin '${name}' unloaded)`);
+        }
+      });
+
       // 6. Reset and clear rate limiters
       plugin.rateLimiters.api.reset();
       plugin.rateLimiters.storage.reset();
@@ -1183,6 +1340,37 @@ export class PluginRuntime {
   // Get a specific plugin
   getPlugin(name: string): LoadedPlugin | undefined {
     return this.plugins.get(name);
+  }
+
+  // fan a search query out to all registered search sources.
+  // returns a Promise that resolves with all results once every source has reported back.
+  resolveSearch(query: SearchQuery): Promise<SearchResult[]> {
+    return new Promise((resolve) => {
+      const collected: SearchResult[] = [];
+      const pending = new Set(this.searchSources.keys());
+
+      if (pending.size === 0) {
+        console.warn(`[PluginRuntime] resolveSearch called but no search sources are registered`);
+        resolve(collected);
+        return;
+      }
+
+      for (const [sourceId, handler] of this.searchSources) {
+        const wrappedOnResult = (result: SearchResult) => {
+          result.sourceId = sourceId;
+          collected.push(result);
+          pending.delete(sourceId);
+          if (pending.size === 0) resolve(collected);
+        };
+
+        try {
+          handler(query, wrappedOnResult);
+        } catch (err) {
+          console.error(`[PluginRuntime] Search source '${sourceId}' threw synchronously:`, err);
+          wrappedOnResult({ sourceId, status: 'error', error: err as Error });
+        }
+      }
+    });
   }
 
   // Resolve stream URL for external tracks

--- a/src/lib/plugins/runtime.ts
+++ b/src/lib/plugins/runtime.ts
@@ -136,8 +136,6 @@ export interface SearchResult {
   track_number?: number | null;
   disc_number?: number | null;
   cover_url?: string | null;
-  album_art?: string | null;
-  track_cover?: string | null;
   // Identifiers
   musicbrainz_recording_id?: string | null;
 
@@ -699,8 +697,6 @@ export class PluginRuntime {
             album: trackData.album || null,
             duration: trackData.duration || null,
             cover_url: trackData.cover_url || null,
-            album_art: trackData.album_art || null,
-            track_cover: trackData.track_cover || null,
             source_type: trackData.source_type,
             external_id: trackData.external_id,
             format: trackData.format || null,
@@ -834,8 +830,6 @@ export class PluginRuntime {
         album?: string | null;
         duration?: number | null;
         cover_url?: string | null;
-        album_art?: string | null;
-        track_cover?: string | null;
         source_type: string;
         external_id: string;
         format?: string | null;


### PR DESCRIPTION
added cross plugin search registry to runtime
1. plugins register themselves as sources. ownership is tracked for cleanup
2. requester plugin directly queries the runtime. which fans out queries to all the registered sources
3. fire onAlldone when all sources are done. either with result or with error
4. added new types that were required

reason :
current spotify plugin needs to hardcode the querying of other plugins. this is very inefficient as we will keep adding new sources. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cross-plugin search framework allowing plugins to register and provide custom search sources
  * Extended external track metadata handling to accept track numbers, disc numbers, source identifiers, and additional metadata
  * Plugin search queries now dispatch across registered sources in parallel with unified result aggregation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->