### PR TITLE
fix : added UA and header overwrite 

### DIFF
--- a/src-tauri/src/commands/library.rs
+++ b/src-tauri/src/commands/library.rs
@@ -1134,6 +1134,8 @@ pub struct ExternalTrackInput {
     pub format: Option<String>,
     pub bitrate: Option<i32>,
     pub stream_url: Option<String>, // The decoded stream URL
+    pub track_number: Option<i32>,
+    pub disc_number: Option<i32>,
 }
 
 /// Add an external (streaming) track to the library
@@ -1172,8 +1174,8 @@ pub async fn add_external_track(
         title: Some(track.title),
         artist: Some(track.artist),
         album: track.album,
-        track_number: None,
-        disc_number: None,
+        track_number: track.track_number,
+        disc_number: track.disc_number,
         duration: track.duration,
         album_art: None,   // External tracks use cover_url instead
         track_cover: None, // External tracks use cover_url instead

--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -399,6 +399,11 @@ async fn write_metadata_to_file(
             tag.set_track(track_num as u32);
         }
     }
+    if let Some(disc_num) = input.disc_number {
+        if disc_num > 0 && disc_num <= 255 {
+            tag.set_disk(disc_num as u32);
+        }
+    }
 
     // If we have cover data, embed it
     if let Some(cover_data) = cover_data {
@@ -668,6 +673,11 @@ async fn write_m4a_metadata(
             tag.set_track_number(track_num as u16);
         }
     }
+    if let Some(disc_num) = input.disc_number {
+        if disc_num > 0 && (disc_num as u32) <= u16::MAX as u32 {
+            tag.set_disc_number(disc_num as u16);
+        }
+    }
 
     // Download and set cover art if URL provided
     if let Some(cover_data) = cover_data {
@@ -738,6 +748,9 @@ fn write_flac_metadata(
     }
     if let Some(track_num) = input.track_number {
         tag.set_vorbis("TRACKNUMBER", vec![track_num.to_string()]);
+    }
+    if let Some(disc_num) = input.disc_number {
+        tag.set_vorbis("DISCNUMBER", vec![disc_num.to_string()]);
     }
     // Add cover art if available
     if let Some(cover_data) = cover_data {

--- a/src-tauri/src/commands/network.rs
+++ b/src-tauri/src/commands/network.rs
@@ -2,6 +2,7 @@
 // These commands allow the frontend/plugins to make HTTP requests through the Rust backend,
 // bypassing browser CORS restrictions.
 
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -32,19 +33,26 @@ pub async fn proxy_fetch(request: ProxyFetchRequest) -> Result<ProxyFetchRespons
 
     let mut req_builder = client.request(method, &request.url);
 
-    // Add default browser-like headers to avoid 403 errors
-    req_builder = req_builder
-        .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
-        .header("Accept", "application/json, text/plain, */*")
-        .header("Accept-Language", "en-US,en;q=0.9")
-        .header("Cache-Control", "no-cache");
+    // Build a HeaderMap so custom headers override defaults
+    let mut header_map = HeaderMap::new();
+    header_map.insert("User-Agent",      HeaderValue::from_static("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"));
+    header_map.insert("Accept",          HeaderValue::from_static("application/json, text/plain, */*"));
+    header_map.insert("Accept-Language", HeaderValue::from_static("en-US,en;q=0.9"));
+    header_map.insert("Cache-Control",   HeaderValue::from_static("no-cache"));
 
-    // Add custom headers (these will override defaults if specified)
+    // Custom headers override defaults (replaces existing keys)
     if let Some(headers) = request.headers {
         for (key, value) in headers {
-            req_builder = req_builder.header(&key, &value);
+            if let (Ok(name), Ok(val)) = (
+                HeaderName::from_bytes(key.as_bytes()),
+                HeaderValue::from_str(&value),
+            ) {
+                header_map.insert(name, val);
+            }
         }
     }
+
+    req_builder = req_builder.headers(header_map);
 
     // Add body if present
     if let Some(body) = request.body {

--- a/src/lib/api/tauri.ts
+++ b/src/lib/api/tauri.ts
@@ -278,6 +278,8 @@ export interface ExternalTrackInput {
     external_id: string;  // Source-specific ID
     format?: string;
     bitrate?: number;
+    track_number?: number;
+    disc_number?: number;
 }
 
 export async function addExternalTrack(track: ExternalTrackInput): Promise<number> {

--- a/src/lib/lyrics/applemusic.ts
+++ b/src/lib/lyrics/applemusic.ts
@@ -93,7 +93,10 @@ export class AppleMusic {
 
     private async _fetch<T>(url: string): Promise<T> {
         return proxyFetch<T>(url, {
-            headers: { 'Accept': 'application/json' }
+            headers: {
+                'Accept': 'application/json',
+                'User-Agent': 'applelyrics/1.0 (github.com/apple/lyrics)'
+            }
         });
     }
 
@@ -106,7 +109,8 @@ export class AppleMusic {
                 `${SEARCH_BASE_URL}/apple-music/search?q=${encodeURIComponent(query)}`
             ) as AppleMusicSearchResult[];
             return Array.isArray(data) && data.length > 0 ? data : null;
-        } catch {
+        } catch (e) {
+            console.log('[AppleMusic] _search failed:', e);
             return null;
         }
     }
@@ -220,6 +224,7 @@ export class AppleMusic {
             }
 
             // ISRC provided but matched nothing . all results are wrong, bail out
+            console.warn('[AppleMusic] ISRC provided but no match found, bailing');
             return null;
         }
 
@@ -242,7 +247,8 @@ export class AppleMusic {
 
             if (!data || data.ok === false) return null;
             return JSON.stringify(data);
-        } catch {
+        } catch (e) {
+            console.error('[AppleMusic] getRawLyrics threw for trackId:', trackId, e);
             return null;
         }
     }
@@ -282,7 +288,8 @@ export class AppleMusic {
                 hasSyllableSync,
                 raw,
             };
-        } catch {
+        } catch (e) {
+            console.error('[AppleMusic] parse_apple_lyrics_json_cmd threw:', e);
             return null;
         }
     }

--- a/src/lib/plugins/runtime.ts
+++ b/src/lib/plugins/runtime.ts
@@ -649,7 +649,9 @@ export class PluginRuntime {
             external_id: trackData.external_id,
             format: trackData.format || null,
             bitrate: trackData.bitrate || null,
-            stream_url: trackData.stream_url || null  // The decoded stream URL
+            stream_url: trackData.stream_url || null,  // The decoded stream URL
+            track_number: trackData.track_number || null,
+            disc_number: trackData.disc_number || null,
           }
         });
 

--- a/src/lib/services/downloadService.ts
+++ b/src/lib/services/downloadService.ts
@@ -176,6 +176,7 @@ export async function downloadTrack(
                 artist: track.artist || null,
                 album: track.album || null,
                 track_number: track.track_number || null,
+                disc_number: track.disc_number || null,
                 cover_url: track.cover_url || null
             }
         });


### PR DESCRIPTION
1. added UA for apple lyrics
2. fixed newwork.rs so that custom headers overwrite instead of append
3. added track number and disc numbers in the online sources chain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for track number and disc number metadata on external and streaming tracks.
  * Disc number metadata is now written to audio files (MP4, FLAC, and other formats).

* **Improvements**
  * Enhanced error logging and visibility for Apple Music lyrics fetching to aid in troubleshooting.
  * Improved internal HTTP header handling for better request reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->