### PR TITLE
fix : add fallback for apple music lyrics search

### DIFF
--- a/src/lib/components/LyricsPanel.svelte
+++ b/src/lib/components/LyricsPanel.svelte
@@ -174,15 +174,24 @@
     // Close the menu whenever a search completes (loading -> done)
     $: if (!$lyricsLoading) sourceMenuOpen = false;
 
-    function showPaxKeyToast() {
+    function showPaxKeyToast(message: string) {
         const toast = document.createElement('div');
         toast.style.cssText = `position:fixed; bottom:100px; left:50%; transform:translateX(-50%); background:#c0392b; color:#fff; padding:10px 20px; border-radius:8px; z-index:10002; font-size:13px; box-shadow:0 4px 12px rgba(0,0,0,0.3); opacity:0; transition:0.3s; display:flex; align-items:center; gap:12px; white-space:nowrap;`;
         const text = document.createElement('span');
-        text.textContent = 'Genius lyrics require a Paxsenix API key. Add it in the Qobuz plugin settings.';
+        text.textContent = message;
         toast.appendChild(text);
         document.body.appendChild(toast);
         requestAnimationFrame(() => toast.style.opacity = '1');
         setTimeout(() => { toast.style.opacity = '0'; setTimeout(() => toast.remove(), 300); }, 4000);
+    }
+
+    let _appleKeyToastShown = false;
+    $: if ($selectedSource === 'applejson' && !$lyricsLoading) {
+        const key = localStorage.getItem('qobuz_pax_api_key')?.trim() ?? '';
+        if (!key && !_appleKeyToastShown) {
+            _appleKeyToastShown = true;
+            showPaxKeyToast('It is advised that you install the Qobuz plugin and configure your Paxsenix key in its settings for reliable Apple Music lyrics.');
+        }
     }
 
     async function handleSourceSelect(sourceId: string) {
@@ -192,8 +201,15 @@
         if (sourceId === 'genius') {
             const key = localStorage.getItem('qobuz_pax_api_key')?.trim() ?? '';
             if (!key) {
-                showPaxKeyToast();
+                showPaxKeyToast('Genius lyrics require a Paxsenix API key. Add it in the Qobuz plugin settings.');
                 return;
+            }
+        }
+
+        if (sourceId === 'applejson') {
+            const key = localStorage.getItem('qobuz_pax_api_key')?.trim() ?? '';
+            if (!key) {
+                showPaxKeyToast('It is advised that you install the Qobuz plugin and configure your Paxsenix key in its settings for reliable Apple Music lyrics.');
             }
         }
 

--- a/src/lib/lyrics/applemusic.ts
+++ b/src/lib/lyrics/applemusic.ts
@@ -9,7 +9,17 @@ import { proxyFetch } from '../network';
 import type { LyricsResult, LyricLine, WordTiming } from './index';
 
 const SEARCH_BASE_URL = 'https://lyrics.paxsenix.org';
+const API_BASE_URL    = 'https://api.paxsenix.org';
 const TIMEOUT = 10000;
+
+/**
+ * read the paxsenix API key from localStorage at call time
+ */
+function getPaxsenixApiKey(): string | null {
+    const raw = localStorage.getItem('qobuz_pax_api_key')?.trim();
+    if (!raw) return null;
+    return raw.startsWith('Bearer ') ? raw : `Bearer ${raw}`;
+}
 
 // ---------------------------------------------------------------------------
 // Raw types from Rust parser
@@ -47,12 +57,42 @@ interface AppleRawLine {
 // ---------------------------------------------------------------------------
 
 interface AppleMusicSearchResult {
-    id:          string;
-    songName:    string;
+    // lyrics.paxsenix.org shape
+    id?:         string;
+    songName?:   string;
+    // api.paxsenix.org shape
+    playParams?: { id: string; kind: string };
+    name?:       string;
+    durationInMillis?: number;
+    hasLyrics?:  boolean;
+    hasTimeSyncedLyrics?: boolean;
+    // shared
     artistName:  string;
     albumName:   string;
-    duration:    number;  // milliseconds
+    duration?:   number;  // milliseconds (lyrics.paxsenix.org)
     isrc:        string;
+}
+
+/** normalise a result from either endpoint into consistent field names */
+function normaliseResult(r: AppleMusicSearchResult): { id: string; songName: string; artistName: string; albumName: string; duration: number; isrc: string; hasLyrics: boolean; hasTimeSyncedLyrics: boolean } {
+    return {
+        id:                   r.playParams?.id ?? r.id ?? '',
+        songName:             r.name          ?? r.songName ?? '',
+        artistName:           r.artistName,
+        albumName:            r.albumName,
+        duration:             r.durationInMillis ?? r.duration ?? 0,
+        isrc:                 r.isrc,
+        hasLyrics:            r.hasLyrics            ?? true,  // default true for lyrics.paxsenix.org which doesn't include this field
+        hasTimeSyncedLyrics:  r.hasTimeSyncedLyrics  ?? true,
+    };
+}
+
+/** unwrap the results array from either endpoint's response shape */
+function unwrapResults(data: unknown): AppleMusicSearchResult[] | null {
+    if (Array.isArray(data)) return data.length > 0 ? data : null;
+    const obj = data as { ok?: boolean; results?: AppleMusicSearchResult[] };
+    if (obj?.results && Array.isArray(obj.results) && obj.results.length > 0) return obj.results;
+    return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -100,17 +140,48 @@ export class AppleMusic {
         });
     }
 
+    private async _fetchWithApiKey<T>(url: string): Promise<T> {
+        const auth = getPaxsenixApiKey(); // already includes "Bearer " prefix
+        return proxyFetch<T>(url, {
+            headers: {
+                'Accept':     'application/json',
+                'User-Agent': 'applelyrics/1.0 (github.com/apple/lyrics)',
+                ...(auth ? { 'Authorization': auth } : {}),
+            }
+        });
+    }
+
     /**
-     * Run a search query and return parsed results, or null on failure / empty.
+     * run a search query and return parsed results, or null on failure / empty
+     * primary: api.paxsenix.org   (Bearer token from localStorage)
+     * fallback: lyrics.paxsenix.org (no auth)
      */
     private async _search(query: string): Promise<AppleMusicSearchResult[] | null> {
+        // primary: api.paxsenix.org
+        const primaryUrl = `${API_BASE_URL}/apple-music/search?q=${encodeURIComponent(query)}`;
         try {
-            const data = await this._fetch(
-                `${SEARCH_BASE_URL}/apple-music/search?q=${encodeURIComponent(query)}`
-            ) as AppleMusicSearchResult[];
-            return Array.isArray(data) && data.length > 0 ? data : null;
+            const raw = await this._fetchWithApiKey(primaryUrl);
+            const data = unwrapResults(raw);
+            if (data) {
+                return data;
+            }
+            console.warn(`[AppleMusic] _search primary returned empty for "${query}"`);
         } catch (e) {
-            console.log('[AppleMusic] _search failed:', e);
+            console.warn(`[AppleMusic] _search primary failed for "${query}":`, e);
+        }
+
+        // fallback: lyrics.paxsenix.org
+        const fallbackUrl = `${SEARCH_BASE_URL}/apple-music/search?q=${encodeURIComponent(query)}`;
+        try {
+            const raw = await this._fetch(fallbackUrl);
+            const data = unwrapResults(raw);
+            if (data) {
+                return data;
+            }
+            console.warn(`[AppleMusic] _search fallback returned empty for "${query}"`);
+            return null;
+        } catch (e) {
+            console.warn(`[AppleMusic] _search fallback failed for "${query}":`, e);
             return null;
         }
     }
@@ -123,10 +194,17 @@ export class AppleMusic {
         results: AppleMusicSearchResult[],
         isrc:    string,
     ): string | null {
-        const match = results.find(
-            r => r.isrc?.toUpperCase() === isrc.toUpperCase()
-        );
-        return match?.id ?? null;
+        for (const r of results) {
+            const n = normaliseResult(r);
+            if (n.isrc?.toUpperCase() === isrc.toUpperCase()) {
+                if (!n.hasLyrics) {
+                    console.warn(`[AppleMusic] ISRC match found (id=${n.id}) but Apple reports hasLyrics=false, skipping`);
+                    return null;
+                }
+                return n.id;
+            }
+        }
+        return null;
     }
 
     /**
@@ -150,39 +228,50 @@ export class AppleMusic {
     ): string | null {
         const norm = (s: string) => s.toLowerCase().trim();
 
-        let best:      AppleMusicSearchResult | null = null;
+        let bestId:    string | null = null;
         let bestScore  = 0;
 
         for (const r of results) {
+            const n = normaliseResult(r);
+
+            // skip tracks Apple explicitly marks as having no lyrics
+            if (!n.hasLyrics) {
+                console.log(`[AppleMusic] Skipping "${n.songName}" by ${n.artistName} (id=${n.id}) — hasLyrics=false`);
+                continue;
+            }
+
             let score = 0;
 
-            if (norm(r.artistName).includes(norm(artist)) ||
-                norm(artist).includes(norm(r.artistName))) {
+            if (norm(n.artistName).includes(norm(artist)) ||
+                norm(artist).includes(norm(n.artistName))) {
                 score += 3;
             }
 
-            if (norm(r.songName).includes(norm(title)) ||
-                norm(title).includes(norm(r.songName))) {
+            if (norm(n.songName).includes(norm(title)) ||
+                norm(title).includes(norm(n.songName))) {
                 score += 2;
             }
 
             if (duration != null) {
                 const durationMs = duration * 1000;
-                if (Math.abs(r.duration - durationMs) <= 3000) score += 2;
+                if (Math.abs(n.duration - durationMs) <= 3000) score += 2;
             }
 
-            if (album && norm(r.albumName).includes(norm(album))) {
+            if (album && norm(n.albumName).includes(norm(album))) {
                 score += 1;
             }
 
+            // bonus for time-synced lyrics
+            if (n.hasTimeSyncedLyrics) score += 1;
+
             if (score > bestScore) {
                 bestScore = score;
-                best      = r;
+                bestId    = n.id;
             }
         }
 
         const MIN_SCORE = 5;
-        return (best && bestScore >= MIN_SCORE) ? best.id : null;
+        return (bestId && bestScore >= MIN_SCORE) ? bestId : null;
     }
 
     /**
@@ -190,8 +279,8 @@ export class AppleMusic {
      *
      * Strategy when ISRC is provided:
      *   1. Search with "title artist", try ISRC match.
-     *   2. If no match, retry with alternate query ("title album" or "artist title").
-     *   3. If still no match , return null. A confirmed ISRC mismatch means every
+     *   2. If no match, retry with title-only query
+     *   3. If still no match, return null. A confirmed ISRC mismatch means every
      *      result in the pool is wrong; skipping to the next provider.
      *
      * Strategy when ISRC is absent:
@@ -206,49 +295,106 @@ export class AppleMusic {
         isrc?:     string | null,
     ): Promise<string | null> {
         const primaryQuery   = `${title} ${artist}`;
-        const alternateQuery = album ? `${title} ${album}` : `${artist} ${title}`;
+        // Strip "feat. ..." / "ft. ..." from artist for a cleaner fallback query
+        const cleanArtist    = artist.replace(/\s*(feat\.|ft\.|featuring)[^,&]*/i, '').trim();
+        const cleanQuery     = cleanArtist && cleanArtist !== artist ? `${title} ${cleanArtist}` : null;
+        const alternateQuery = title;
+
+        console.log(`[AppleMusic] getTrackId — title="${title}" artist="${artist}" album="${album ?? '-'}" duration=${duration ?? '-'}s isrc="${isrc ?? '-'}"`);
 
         if (isrc) {
             // --- ISRC path ---
             const results = await this._search(primaryQuery);
             if (results) {
                 const id = this._matchByIsrc(results, isrc);
-                if (id) return id;
+                if (id) { console.log(`[AppleMusic] ISRC matched on primary query — id=${id}`); return id; }
+                console.warn(`[AppleMusic] ISRC "${isrc}" not found in ${results.length} primary results:`, results.map(r => r.isrc));
             }
 
-            // Retry with alternate query before giving up
+            // retry with clean artist query (feat. stripped) if different from primary
+            if (cleanQuery) {
+                const cleanResults = await this._search(cleanQuery);
+                if (cleanResults) {
+                    const id = this._matchByIsrc(cleanResults, isrc);
+                    if (id) { console.log(`[AppleMusic] ISRC matched on clean artist query — id=${id}`); return id; }
+                    console.warn(`[AppleMusic] ISRC "${isrc}" not found in ${cleanResults.length} clean artist results:`, cleanResults.map(r => r.isrc));
+                }
+            }
+
+            // retry with title-only query before giving up
             const retryResults = await this._search(alternateQuery);
             if (retryResults) {
                 const id = this._matchByIsrc(retryResults, isrc);
-                if (id) return id;
+                if (id) { console.log(`[AppleMusic] ISRC matched on title-only query — id=${id}`); return id; }
+                console.warn(`[AppleMusic] ISRC "${isrc}" not found in ${retryResults.length} title-only results:`, retryResults.map(r => r.isrc));
             }
 
             // ISRC provided but matched nothing . all results are wrong, bail out
-            console.warn('[AppleMusic] ISRC provided but no match found, bailing');
+            console.warn('[AppleMusic] ISRC provided but no match found in any query, bailing');
             return null;
         }
 
         // --- Fuzzy path ---
         const results = await this._search(primaryQuery);
-        if (!results) return null;
+        if (results) {
+            const id = this._matchByMetadata(results, title, artist, album, duration);
+            if (id) { console.log(`[AppleMusic] Fuzzy matched on primary query — id=${id}`); return id; }
+            console.warn(`[AppleMusic] Fuzzy match failed on primary query — best candidates:`, results.slice(0, 3).map(r => `"${r.songName}" by ${r.artistName} (${r.duration}ms)`));
+        }
 
-        return this._matchByMetadata(results, title, artist, album, duration);
+        // retry with clean artist query (feat. stripped) if different from primary
+        if (cleanQuery) {
+            const cleanResults = await this._search(cleanQuery);
+            if (cleanResults) {
+                const id = this._matchByMetadata(cleanResults, title, artist, album, duration);
+                if (id) { console.log(`[AppleMusic] Fuzzy matched on clean artist query — id=${id}`); return id; }
+                console.warn(`[AppleMusic] Fuzzy match failed on clean artist query — best candidates:`, cleanResults.slice(0, 3).map(r => `"${r.songName}" by ${r.artistName} (${r.duration}ms)`));
+            }
+        }
+
+        // retry with title-only query
+        const retryResults = await this._search(alternateQuery);
+        if (!retryResults) {
+            console.warn(`[AppleMusic] Fuzzy path — title-only query also returned nothing, giving up`);
+            return null;
+        }
+
+        const id = this._matchByMetadata(retryResults, title, artist, album, duration);
+        if (id) { console.log(`[AppleMusic] Fuzzy matched on title-only query — id=${id}`); }
+        else     { console.warn(`[AppleMusic] Fuzzy match failed on title-only query — best candidates:`, retryResults.slice(0, 3).map(r => `"${r.songName}" by ${r.artistName} (${r.duration}ms)`)); }
+        return id;
     }
 
     /**
      * Fetch raw Apple Music lyrics JSON by track ID.
      * Returns the raw JSON string for Rust to parse.
+     * primary: lyrics.paxsenix.org (no auth)
+     * fallback: api.paxsenix.org   (Bearer token from localStorage)
      */
     async getRawLyrics(trackId: string): Promise<string | null> {
+        // primary
+        const primaryUrl = `${SEARCH_BASE_URL}/apple-music/lyrics?id=${encodeURIComponent(trackId)}`;
         try {
-            const data = await this._fetch(
-                `${SEARCH_BASE_URL}/apple-music/lyrics?id=${encodeURIComponent(trackId)}`
-            ) as { ok?: boolean; [key: string]: unknown };
+            const data = await this._fetch(primaryUrl) as { ok?: boolean; error?: boolean; message?: string; [key: string]: unknown };
+            if (data && data.ok !== false && !data.error) {
+                return JSON.stringify(data);
+            }
+            console.warn(`[AppleMusic] getRawLyrics primary returned no lyrics for trackId=${trackId}:`, { ok: data?.ok, error: data?.error, message: data?.message });
+        } catch (e) {
+            console.warn(`[AppleMusic] getRawLyrics primary failed for trackId=${trackId}:`, e);
+        }
 
-            if (!data || data.ok === false) return null;
+        // fallback
+        const fallbackUrl = `${API_BASE_URL}/lyrics/applemusic?id=${encodeURIComponent(trackId)}`;
+        try {
+            const data = await this._fetchWithApiKey(fallbackUrl) as { ok?: boolean; error?: boolean; message?: string; [key: string]: unknown };
+            if (!data || data.ok === false) {
+                console.warn(`[AppleMusic] getRawLyrics fallback returned ok=false for trackId=${trackId}`);
+                return null;
+            }
             return JSON.stringify(data);
         } catch (e) {
-            console.error('[AppleMusic] getRawLyrics threw for trackId:', trackId, e);
+            console.error(`[AppleMusic] getRawLyrics fallback failed for trackId=${trackId}:`, e);
             return null;
         }
     }


### PR DESCRIPTION
add paxsenix fallback for apple lyrics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API key validation with user-friendly notifications when required credentials are missing.
  * Enhanced Apple Music lyrics lookup with intelligent fallback mechanisms.

* **Bug Fixes**
  * Improved track matching to better handle artist name variations and metadata inconsistencies.
  * Enhanced lyrics retrieval with automatic fallback when primary source fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dupitydumb/Audion/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->