### PR TITLE
docs: add native Arch Linux installation instructions (audion-bin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ Get the latest builds from [Releases](https://github.com/dupitydumb/Audion/relea
 - **macOS (dmg):** Audion.dmg
 - **Linux (AppImage):** Audion-x86_64.AppImage
 - **Linux (Flatpak):** audion_<version>_linux.flatpak
+- **Arch Linux (AUR):** `yay -S audion-bin` (Community maintained, auto-updating binary)
+
+### Installation Notes
+
+#### Arch Linux / Arch-based Distros
+You can install Audion directly from the Arch User Repository (AUR) using your preferred AUR helper:
+
+```bash
+# Using yay
+yay -S audion-bin
+
+# Using paru
+paru -S audion-bin
+```
 
 If you prefer, download the platform-specific asset from the Releases page for your OS.
 


### PR DESCRIPTION
### Overview
This pull request adds clear, native installation instructions for Arch Linux and Arch-based distributions directly to the `README.md`. 

### The Problem
Currently, users on Arch Linux face friction running the AppImage/Flatpak distributions due to system dependency mismatches, frequently forcing them to manually clone and compile the entire Node.js/Rust toolchain from source. 

### The Solution
To streamline the onboarding experience for Arch users, I have packaged the pre-compiled Linux `.deb` asset and officially published it to the Arch User Repository (AUR) under the package name [**`audion-bin`**](https://aur.archlinux.org/packages/audion-bin).

### Key Features of this Package:
* **Zero Maintenance for Upstream:** You do not have to do a single thing when you drop a new release. I have configured a completely automated GitHub Actions pipeline in my deployment mirror (`Kavy-Codes/audion-bin`) that polls your repository daily.
* **Instant Synchronicity:** Within 24 hours of you releasing a new tag here, the pipeline automatically bumps the version strings and pushes the fresh binary straight to the AUR.
* **Native Integration:** Arch users can now install and update Audion dynamically through their system package managers (`yay`, `paru`) like a native desktop app, handles icons, desktop environment triggers, and launchers flawlessly.

This change places Arch Linux as a first-class citizen alongside Windows and macOS in your documentation, making this gorgeous player instantly accessible to a massive ecosystem of users with zero technical or maintenance overhead for you.

Thank you for building such an incredibly slick media player!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Arch Linux (AUR) installation option to the Quick Start guide.
  * Included installation notes for Arch and Arch-based distributions with step-by-step instructions for installing via yay or paru package managers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->